### PR TITLE
improve logging in the bookkeeper package

### DIFF
--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -34,7 +34,11 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	res, err := bookkeeper.NewService().RenderConfig(context.Background(), req)
+	res, err := bookkeeper.NewService(
+		&bookkeeper.ServiceOptions{
+			LogLevel: bookkeeper.LogLevel(logger.Level),
+		},
+	).RenderConfig(context.Background(), req)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/cmd/cli/render_cmd.go
+++ b/cmd/cli/render_cmd.go
@@ -134,7 +134,12 @@ func runRenderCmd(cmd *cobra.Command, args []string) error {
 	// based on whether this is the thin or thick CLI...
 	var svc bookkeeper.Service
 	if cmd.Flags().Lookup(flagServer) == nil { // Thick CLI
-		svc = bookkeeper.NewService()
+		svc = bookkeeper.NewService(
+			&bookkeeper.ServiceOptions{
+				// TODO: We should support a debug flag
+				LogLevel: bookkeeper.LogLevelInfo,
+			},
+		)
 	} else { // Thin CLI
 		if svc, err = getClient(cmd); err != nil {
 			return err

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,7 +47,13 @@ func main() {
 	router.StrictSlash(true)
 	router.HandleFunc(
 		"/v1alpha1/render",
-		getRenderRequestHandler(bookkeeper.NewService()),
+		getRenderRequestHandler(
+			bookkeeper.NewService(
+				&bookkeeper.ServiceOptions{
+					LogLevel: bookkeeper.LogLevel(logger.Level),
+				},
+			),
+		),
 	).Methods(http.MethodPost)
 	router.HandleFunc("/version", handleVersionRequest).Methods(http.MethodGet)
 	router.HandleFunc("/healthz", libHTTP.Healthz).Methods(http.MethodGet)

--- a/logger.go
+++ b/logger.go
@@ -1,5 +1,0 @@
-package bookkeeper
-
-import libLog "github.com/akuityio/bookkeeper/internal/log"
-
-var logger = libLog.LoggerOrDie()

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,17 @@
+package bookkeeper
+
+import log "github.com/sirupsen/logrus"
+
+// LogLevel represents the level of detail logged by the Bookkeeper service's
+// internal logger.
+type LogLevel log.Level
+
+const (
+	// LogLevelDebug represents DEBUG level logging.
+	LogLevelDebug = LogLevel(log.DebugLevel)
+	// LogLevelInfo represents INFO level logging. This is the default for the
+	// Bookkeeper service when no LogLevel is explicitly specified.
+	LogLevelInfo = LogLevel(log.InfoLevel)
+	// LogLevelError represents ERROR level logging.
+	LogLevelError = LogLevel(log.ErrorLevel)
+)


### PR DESCRIPTION
Up to now, the log level was controlled entirely with an environment variable. That's fine for our own stuff, but I imagine third parties using the `bookkeeper` package as a library (at the very least, K8sTA will use it), so it is better if the log level for the Bookkeeper service can be specified through an options object at the time it's instantiated.