### PR TITLE
fix packaging problem

### DIFF
--- a/cmd/action/request.go
+++ b/cmd/action/request.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 
 	"github.com/akuityio/bookkeeper"
-	"github.com/akuityio/bookkeeper/internal/git"
 	libOS "github.com/akuityio/bookkeeper/internal/os"
 )
 
 func request() (bookkeeper.RenderRequest, error) {
 	req := bookkeeper.RenderRequest{
-		RepoCreds: git.RepoCredentials{
+		RepoCreds: bookkeeper.RepoCredentials{
 			Username: "git",
 		},
 		Images: libOS.GetStringSliceFromEnvVar("INPUT_IMAGES", nil),

--- a/cmd/action/request_test.go
+++ b/cmd/action/request_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/akuityio/bookkeeper"
-	"github.com/akuityio/bookkeeper/internal/git"
 )
 
 func TestRequest(t *testing.T) {
@@ -25,7 +24,7 @@ func TestRequest(t *testing.T) {
 	)
 	testReq := bookkeeper.RenderRequest{
 		RepoURL: fmt.Sprintf("https://github.com/%s", testRepo),
-		RepoCreds: git.RepoCredentials{
+		RepoCreds: bookkeeper.RepoCredentials{
 			Username: "git",
 			Password: "12345", // Like something an idiot would use for their luggage
 		},

--- a/service.go
+++ b/service.go
@@ -68,7 +68,15 @@ func (s *service) RenderConfig(
 
 	res := RenderResponse{}
 
-	repo, err := git.Clone(ctx, req.RepoURL, req.RepoCreds)
+	repo, err := git.Clone(
+		ctx,
+		req.RepoURL,
+		git.RepoCredentials{
+			SSHPrivateKey: req.RepoCreds.SSHPrivateKey,
+			Username:      req.RepoCreds.Username,
+			Password:      req.RepoCreds.Password,
+		},
+	)
 	if err != err {
 		return res, errors.Wrap(err, "error cloning remote repository")
 	}

--- a/types.go
+++ b/types.go
@@ -1,9 +1,5 @@
 package bookkeeper
 
-import (
-	"github.com/akuityio/bookkeeper/internal/git"
-)
-
 // ActionTaken indicates what action, if any was taken in response to a
 // RenderRequest.
 type ActionTaken string
@@ -32,7 +28,7 @@ type RenderRequest struct {
 	RepoURL string `json:"repoURL,omitempty"`
 	// RepoCreds encapsulates read/write credentials for the remote GitOps
 	// repository referenced by the RepoURL field.
-	RepoCreds git.RepoCredentials `json:"repoCreds,omitempty"`
+	RepoCreds RepoCredentials `json:"repoCreds,omitempty"`
 	// Commit specifies a precise commit to render configuration from. When this
 	// is omitted, the request is assumed to be one to render from the head of the
 	// default branch.
@@ -48,6 +44,22 @@ type RenderRequest struct {
 	// OpenPR specifies whether to open a PR against TargetBranch (true) instead
 	// of directly committing directly to it (false).
 	OpenPR bool `json:"openPR,omitempty"`
+}
+
+// RepoCredentials represents the credentials for connecting to a private git
+// repository.
+type RepoCredentials struct {
+	// SSHPrivateKey is a private key that can be used for both reading from and
+	// writing to some remote repository.
+	SSHPrivateKey string `json:"sshPrivateKey,omitempty"`
+	// Username identifies a principal, which combined with the value of the
+	// Password field, can be used for both reading from and writing to some
+	// remote repository.
+	Username string `json:"username,omitempty"`
+	// Password, when combined with the principal identified by the Username
+	// field, can be used for both reading from and writing to some remote
+	// repository.
+	Password string `json:"password,omitempty"`
 }
 
 // RenderResponse encapsulates details of a successful rendering of some some


### PR DESCRIPTION
This fixes a problem wherein those using Bookkeeper as a library (like K8sTA) couldn't provide repo credentials because that type was defined in an internal package.