### PR TITLE
chore: strike references to k8sta-tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -27,17 +24,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run unit tests
-      env:
-        SKIP_DOCKER: 'true'
       run: make test-unit
 
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/akuityio/k8sta-tools:v0.3.0
-      credentials:
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
+      image: golang:1.19.3-bullseye
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -47,9 +39,12 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Install linter
+      run: |
+        cd /usr/local/bin
+        curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v1.49.0/golangci-lint-1.49.0-linux-amd64.tar.gz \
+          | tar xvz golangci-lint-1.49.0-linux-amd64/golangci-lint --strip-components=1
     - name: Run linter
-      env:
-        SKIP_DOCKER: 'true'
       run: make lint
 
   build-image:
@@ -60,12 +55,6 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
     - name: Build image
       uses: docker/build-push-action@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/akuityio/k8sta-tools:v0.3.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.3-bullseye as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM golang:1.19.3-bullseye
+
+ARG TARGETARCH
+
+ARG GOLANGCI_LINT_VERSION=1.49.0
+
+RUN cd /usr/local/bin \
+    && curl -sSfL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz \
+        | tar xvz golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}/golangci-lint --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,23 @@
 SHELL ?= /bin/bash
 
-ifneq ($(SKIP_DOCKER),true)
-	DOCKER_CMD := docker run \
-		-it \
-		--rm \
-		-e SKIP_DOCKER=true \
-		-v gomodcache:/go/pkg/mod \
-		-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/bookkeeper \
-		-w /workspaces/bookkeeper \
-		ghcr.io/akuityio/k8sta-tools:v0.3.0
-endif
-
 ################################################################################
 # Tests                                                                        #
+#                                                                              #
+# These targets are used by our continuous integration processes. Use these    #
+# directly at your own risk -- they assume required tools (and correct         #
+# versions thereof) to be present on your system.                              #
+#                                                                              #
+# If you prefer to executes these tasks in a container that is pre-loaded with #
+# required tools, refer to the hacking section toward the bottom of this file. #
 ################################################################################
 
 .PHONY: lint
 lint:
-	$(DOCKER_CMD) golangci-lint run --config golangci.yaml
+	golangci-lint run --config golangci.yaml
 
 .PHONY: test-unit
 test-unit:
-	$(DOCKER_CMD) go test \
+	go test \
 		-v \
 		-timeout=120s \
 		-race \
@@ -31,8 +27,31 @@ test-unit:
 
 ################################################################################
 # Hack: Targets to help you hack                                               #
+#                                                                              #
+# These targets minimize required developer setup by executing in a container  #
+# that is pre-loaded with required tools.                                      #
 ################################################################################
 
-.PHONY: hack-build-image
-hack-build-image:
+DOCKER_CMD := docker run \
+	-it \
+	--rm \
+	-v gomodcache:/go/pkg/mod \
+	-v $(dir $(realpath $(firstword $(MAKEFILE_LIST)))):/workspaces/bookkeeper \
+	-w /workspaces/bookkeeper \
+	bookkeeper:dev-tools
+
+.PHONY: hack-build-dev-tools
+hack-build-dev-tools:
+	docker build -f Dockerfile.dev -t bookkeeper:dev-tools .
+
+.PHONY: hack-lint
+hack-lint: hack-build-dev-tools
+	$(DOCKER_CMD) make lint
+
+.PHONY: hack-test-unit
+hack-test-unit: hack-build-dev-tools
+	$(DOCKER_CMD) make test-unit
+
+.PHONY: hack-build
+hack-build:
 	docker build . -t bookkeeper:dev

--- a/docs/docs/40-contributor-guide/10-hacking-on-bookkeeper.md
+++ b/docs/docs/40-contributor-guide/10-hacking-on-bookkeeper.md
@@ -9,38 +9,65 @@ IDE, it is recommended that you have installed the latest stable releases of Go
 and applicable editor/IDE extensions, however, this is not strictly required to
 be successful.
 
-## Containerized tests
+## Running tests
 
 In order to minimize the setup required to successfully apply small changes and
 in order to reduce the incidence of “it worked on my machine,” wherein changes
 that pass tests locally do not pass the same tests in CI due to environmental
-differences, Bookkeeper has adopted a “container-first” approach to testing.
-This is to say we have made it the default that unit tests, linters, and a
-variety of other validations, when executed locally, automatically execute in a
-Docker container that is maximally similar to the container in which those same
-tasks will run during the continuous integration process.
+differences, Bookkeeper has made it trivial to execute tests within a container
+that is maximally similar to the containers that tests execute in during the
+continuous integration process.
 
 To take advantage of this, you only need to have
 [Docker](https://docs.docker.com/engine/install/) and `make` installed.
 
-If you wish to opt-out of tasks automatically running inside a container, you
-can set the environment variable `SKIP_DOCKER` to the value `true`. Doing so
-will require that any tools involved in tasks you execute have been installed
-locally. 
-
-## Testing Bookkeeper code
-
-If you make modifications to the code base, it is recommended that you run
-unit tests and linters before opening a PR.
-
 To run all unit tests:
+
+```shell
+make hack-test-unit
+```
+
+:::info
+If you wish to opt-out of executing the tests within a container, use the
+following instead:
 
 ```shell
 make test-unit
 ```
 
+This will require Go to be installed locally.
+:::
+
 To run lint checks:
+
+```shell
+make hack-lint
+```
+
+:::info
+If you wish to opt-out of executing the linter within a container, use the
+following instead:
 
 ```shell
 make lint
 ```
+
+This will require Go and [golangci-lint](https://golangci-lint.run/) to be
+installed locally.
+:::
+
+## Building the image
+
+To build source into a Docker image that will be tagged as `bookkeeper:dev`,
+execute the following:
+
+```shell
+make hack-build
+```
+
+:::note
+Because Bookkeeper is dependent on compatible versions of Git, Kustomize, ytt,
+and Helm binaries, there is seldom, if ever, a reason to build or execute the
+Bookkeeper binaries outside the context of a container that provides those
+dependencies.
+:::


### PR DESCRIPTION
We will be ready to share Bookkeeper with the world well before we're ready to publicly talk about K8sTA, so this PR aims to strike references to K8sTA from the Bookkeeper code base.

Such references came in mainly in the form of the private `ghcr.io/akuityio/k8sta-tools` image -- which is simply an image pre-loaded with tools used to facilitate development and testing of Bookkeeper and K8sTA.

Rather than simply replace this with something like `ghcr.io/akuityio/bookkeeper-tools` (which does not exist), this PR attempts to implement a sane way of keeping everything (e.g. the definition of that helper image) in one place.