### PR TITLE
improve commit messages

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -23,7 +23,7 @@ type TargetBranchMetadata struct {
 }
 
 // LoadTargetBranchMetadata attempts to load TargetBranchMetadata from a
-// .bookkeeper/metadata.yaml file relative to the specified directory. Iff no
+// .bookkeeper/metadata.yaml file relative to the specified directory. If no
 // such file is found a nil result is returned.
 func LoadTargetBranchMetadata(repoPath string) (*TargetBranchMetadata, error) {
 	path := filepath.Join(


### PR DESCRIPTION
This PR vastly improves commit messages and PR titles + bodies.

Example commit message:

```
Bookkeeper created this commit by rendering configuration from 45e330ea6dc105203d73311f85bff287015c0606

This includes the following changes (newest to oldest):

    * 45e330ea6dc105203d73311f85bff287015c0606 touch bar
    * 89cdd28ee290a6f9fd4e95a1858a3c53c3168f5e touch foo
```

The big difference here from before is that it enumerates _all_ changes between the previous and desired state of the target branch.

This makes is more abundantly clear what is included in the commit / PR.