### PR TITLE
support branch name patterns

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -1,7 +1,9 @@
 package file
 
 import (
+	"fmt"
 	"os"
+	"strings"
 )
 
 // Exists returns a bool indicating if the specified file exists or not. It
@@ -15,4 +17,18 @@ func Exists(filename string) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// ExpandPath expands the provided pathTemplate, replacing placeholders of the
+// form ${n} where n is a non-negative integer, with corresponding values from
+// the provided string array. The expanded path is returned.
+func ExpandPath(pathTemplate string, values []string) string {
+	for i := 0; i < len(values); i++ {
+		pathTemplate = strings.ReplaceAll(
+			pathTemplate,
+			fmt.Sprintf("${%d}", i),
+			values[i],
+		)
+	}
+	return pathTemplate
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -17,3 +17,46 @@ func TestExists(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 }
+
+func TestExpandPath(t *testing.T) {
+	testCases := []struct {
+		name           string
+		pathTemplate   string
+		values         []string
+		expectedOutput string
+	}{
+		{
+			name:           "empty string",
+			pathTemplate:   "",
+			values:         []string{"foo", "bar"},
+			expectedOutput: "",
+		},
+		{
+			name:           "single substitution",
+			pathTemplate:   "this is a ${0} test",
+			values:         []string{"foo", "bar"},
+			expectedOutput: "this is a foo test",
+		},
+		{
+			name:           "multiples substitutions",
+			pathTemplate:   "this is a ${0} ${1} test",
+			values:         []string{"foo", "bar"},
+			expectedOutput: "this is a foo bar test",
+		},
+		{
+			name:           "placeholder with no corresponding value",
+			pathTemplate:   "this is a ${0} ${1} ${2} test",
+			values:         []string{"foo", "bar"},
+			expectedOutput: "this is a foo bar ${2} test",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				testCase.expectedOutput,
+				ExpandPath(testCase.pathTemplate, testCase.values),
+			)
+		})
+	}
+}

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -1,5 +1,7 @@
 package helm
 
+import "github.com/akuityio/bookkeeper/internal/file"
+
 // Config encapsulates optional Helm configuration options.
 type Config struct {
 	// ReleaseName specifies the release name that will be used when executing the
@@ -15,4 +17,18 @@ type Config struct {
 	// `--values` flag in the `helm template` command. By convention, if left
 	// unspecified, one path will be assumed: <branch name>/values.yaml.
 	ValuesPaths []string `json:"valuesPaths,omitempty"`
+}
+
+// Expand expands all file/directory paths referenced by this configuration
+// object, replacing placeholders of the form ${n} where n is a non-negative
+// integer, with corresponding values from the provided string array. The
+// modified object is returned.
+func (c Config) Expand(values []string) Config {
+	cfg := c
+	cfg.ChartPath = file.ExpandPath(c.ChartPath, values)
+	cfg.ValuesPaths = make([]string, len(c.ValuesPaths))
+	for i, pathTemplate := range c.ValuesPaths {
+		cfg.ValuesPaths[i] = file.ExpandPath(pathTemplate, values)
+	}
+	return cfg
 }

--- a/internal/helm/config_test.go
+++ b/internal/helm/config_test.go
@@ -1,0 +1,21 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigExpand(t *testing.T) {
+	const val = "foo"
+	testCfg := Config{
+		ChartPath:   "${0}",
+		ValuesPaths: []string{"${0}", "${0}"},
+	}
+	cfg := testCfg.Expand([]string{val})
+	require.Equal(t, cfg.ChartPath, val)
+	require.Equal(t, cfg.ValuesPaths, []string{val, val})
+	// Check that original testCfg.ValuesPaths are untouched.
+	// Slice references are pointers, hence the extra care.
+	require.Equal(t, []string{"${0}", "${0}"}, testCfg.ValuesPaths)
+}

--- a/internal/kustomize/config.go
+++ b/internal/kustomize/config.go
@@ -1,5 +1,7 @@
 package kustomize
 
+import "github.com/akuityio/bookkeeper/internal/file"
+
 // Config encapsulates optional Kustomize configuration options.
 type Config struct {
 	// Path is a path to a directory, relative to the root of the repository,
@@ -8,4 +10,14 @@ type Config struct {
 	// executed. By convention, if left unspecified, the path is assumed to be
 	// identical to the name of the branch.
 	Path string `json:"path,omitempty"`
+}
+
+// Expand expands all file/directory paths referenced by this configuration
+// object, replacing placeholders of the form ${n} where n is a non-negative
+// integer, with corresponding values from the provided string array. The
+// modified object is returned.
+func (c Config) Expand(values []string) Config {
+	cfg := c
+	cfg.Path = file.ExpandPath(c.Path, values)
+	return cfg
 }

--- a/internal/kustomize/config_test.go
+++ b/internal/kustomize/config_test.go
@@ -1,0 +1,16 @@
+package kustomize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigExpand(t *testing.T) {
+	const val = "foo"
+	testCfg := Config{
+		Path: "${0}",
+	}
+	cfg := testCfg.Expand([]string{val})
+	require.Equal(t, cfg.Path, val)
+}

--- a/internal/ytt/config.go
+++ b/internal/ytt/config.go
@@ -1,5 +1,7 @@
 package ytt
 
+import "github.com/akuityio/bookkeeper/internal/file"
+
 // Config encapsulates optional ytt configuration options.
 type Config struct {
 	// Paths are paths to directories or files, relative to the root of the
@@ -8,4 +10,17 @@ type Config struct {
 	// unspecified, two paths are assumed: base/ and a path identical to the name
 	// of the branch.
 	Paths []string `json:"paths,omitempty"`
+}
+
+// Expand expands all file/directory paths referenced by this configuration
+// object, replacing placeholders of the form ${n} where n is a non-negative
+// integer, with corresponding values from the provided string array. The
+// modified object is returned.
+func (c Config) Expand(values []string) Config {
+	cfg := c
+	cfg.Paths = make([]string, len(c.Paths))
+	for i, pathTemplate := range c.Paths {
+		cfg.Paths[i] = file.ExpandPath(pathTemplate, values)
+	}
+	return cfg
 }

--- a/internal/ytt/config_test.go
+++ b/internal/ytt/config_test.go
@@ -1,0 +1,19 @@
+package ytt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigExpand(t *testing.T) {
+	const val = "foo"
+	testCfg := Config{
+		Paths: []string{"${0}", "${0}"},
+	}
+	cfg := testCfg.Expand([]string{val})
+	require.Equal(t, cfg.Paths, []string{val, val})
+	// Check that original testCfg.Paths are untouched.
+	// Slice references are pointers, hence the extra care.
+	require.Equal(t, []string{"${0}", "${0}"}, testCfg.Paths)
+}

--- a/schema.json
+++ b/schema.json
@@ -11,6 +11,11 @@
 
 		"relativePath": {
 			"type": "string",
+			"pattern": "^(?:\\w|\\.|(?:\\$\\{\\d+\\}))(?:\\w|\\.|/|-|(?:\\$\\{\\d+\\}))*$"
+		},
+
+		"branchName": {
+			"type": "string",
 			"pattern": "^(?:[\\w\\.-]+\/?)*\\w$"
 		},
 
@@ -18,6 +23,12 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
+				"name": {
+					"$ref": "#/definitions/branchName"
+				},
+				"pattern": {
+					"type": "string"
+				},
 				"appConfigs": {
 					"type": "object",
 					"additionalProperties": false,
@@ -150,12 +161,9 @@
 			"$ref": "#/definitions/configVersion"
 		},
 		"branchConfigs": {
-			"type": "object",
-			"additionalProperties": false,
-			"patternProperties": {
-				"^(?:[\\w\\.-]+\/?)*\\w$": {
-					"$ref": "#/definitions/branchConfig"	
-				}
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/branchConfig"
 			}
 		}
 	}

--- a/service.go
+++ b/service.go
@@ -123,7 +123,14 @@ func (s *service) RenderManifests(
 		return res,
 			errors.Wrap(err, "error loading Bookkeeper configuration from repo")
 	}
-	rc.target.branchConfig = repoConfig.BranchConfigs[rc.request.TargetBranch]
+	if rc.target.branchConfig, err =
+		repoConfig.GetBranchConfig(rc.request.TargetBranch); err != nil {
+		return res, errors.Wrapf(
+			err,
+			"error loading configuration for branch %q",
+			rc.request.TargetBranch,
+		)
+	}
 
 	if len(rc.target.branchConfig.AppConfigs) == 0 {
 		rc.target.branchConfig.AppConfigs = map[string]appConfig{


### PR DESCRIPTION
Partially addresses #103

The basic principle behind this is that we look for configuration that exactly matches the target branch name first. If an exact match isn't found, we fall back on looking for configuration with a pattern (regex) that matches the target branch name. Paths within that configuration may uses placeholders of the form `${n}` where `n` in a non-negative integer and those paths will automatically expanded with values from the pattern's capture groups.

This is a huge deal, because it drastically reduces configuration when you are dealing with many branches, as long as those branches have a pretty consistent/predictable relationship to the structure of the repository.

Although this is a big improvement, what it does not yet address is the ability to make minor overrides -- for instance, in a demo repo I've been using, all branches `env/test`, `env/stage`, `env/prod` can be accommodated with a single configuration stanza, but what I've lost is the ability to express that rendering either of the first two of those branches should result in direct commits, rendering the third should result in a PR.

That can be addressed in a follow-up.