### PR TITLE
adjust permissions on release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
 
   build-and-push-image:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU
@@ -16,12 +18,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
     - name: Install Cosign
       uses: sigstore/cosign-installer@v2
-    - name: Login to GHCR
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.GH_USERNAME }}
-        password: ${{ secrets.GH_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: Docker meta


### PR DESCRIPTION
Existing permissions for publishing images to ghcr seems to have been broken by the recent repo and package rename.

Previously, we were managing a token with specific permissions stored as secret `GH_TOKEN`.

This PR just requests the necessary permissions for the default `GITHUB_TOKEN` that is automatically associated with every Actions workflow run.

I am also removing the explicit login step. I _think_ it's not needed anymore when doing things this way. If I'm wrong, I'll be putting that step back later.