### PR TITLE
feat: add --ref-path to render to different path than target-branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 bin/
 coverage.txt
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,10 @@ hack-build:
 		--build-arg GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi) \
 		--tag kargo-render:dev \
 		.
+
+.PHONY: hack-build-cli
+hack-build-cli:
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+      	-ldflags "-w -X ${VERSION_PACKAGE}.version=${VERSION} -X ${VERSION_PACKAGE}.buildDate=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PACKAGE}.gitCommit=${GIT_COMMIT} -X ${VERSION_PACKAGE}.gitTreeState=${GIT_TREE_STATE}" \
+      	-o bin/kargo-render \
+      	./cmd

--- a/cmd/cli/flags.go
+++ b/cmd/cli/flags.go
@@ -15,6 +15,7 @@ const (
 	flagOutputJSON    = "json"
 	flagOutputYAML    = "yaml"
 	flagRef           = "ref"
+	flagRefPath       = "ref-path"
 	flagRepo          = "repo"
 	flagRepoPassword  = "repo-password"
 	flagRepoUsername  = "repo-username"

--- a/cmd/cli/render_cmd.go
+++ b/cmd/cli/render_cmd.go
@@ -25,6 +25,12 @@ func newRenderCommand() (*cobra.Command, error) {
 		"specify a branch or a precise commit to render from; if this is not "+
 			"provided, Kargo Render renders from the head of the default branch",
 	)
+	cmd.Flags().String(
+		flagRefPath,
+		"",
+		"a path in the ref branch/commit to render from; if unspecified, "+
+			"uses target-branch as the path",
+	)
 	cmd.Flags().StringP(
 		flagCommitMessage,
 		"m",
@@ -115,6 +121,10 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	req.Ref, err = cmd.Flags().GetString(flagRef)
+	if err != nil {
+		return err
+	}
+	req.RefPath, err = cmd.Flags().GetString(flagRefPath)
 	if err != nil {
 		return err
 	}

--- a/service.go
+++ b/service.go
@@ -140,10 +140,14 @@ func (s *service) RenderManifests(
 	}
 
 	if len(rc.target.branchConfig.AppConfigs) == 0 {
+		refPath := rc.request.TargetBranch
+		if req.RefPath != "" {
+			refPath = req.RefPath
+		}
 		rc.target.branchConfig.AppConfigs = map[string]appConfig{
 			"app": {
 				ConfigManagement: argocd.ConfigManagementConfig{
-					Path: rc.request.TargetBranch,
+					Path: refPath,
 				},
 			},
 		}

--- a/types.go
+++ b/types.go
@@ -36,6 +36,9 @@ type Request struct {
 	// When this is omitted, the request is assumed to be one to render from the
 	// head of the default branch.
 	Ref string `json:"ref,omitempty"`
+	// RefPath is the path in the Ref branch or commit, to render manifests from.
+	// If omitted, will use TargetBranch as the path.
+	RefPath string `json:"refPath,omitempty"`
 	// TargetBranch is the name of an environment-specific branch in the GitOps
 	// repository referenced by the RepoURL field into which plain YAML should be
 	// rendered.


### PR DESCRIPTION
To support PR promotions in kargo (with the render mechanism), `kargo-render` needs the ability to render to a target branch that is named **_differently_** than the path it is rendering from. This PR adds `--ref-path` so the two can be specified independently. If omitted, it preserves the original behavior of rendering from the path equal to `--target-branch`.