### PR TITLE
docs: helm parameter is valueFiles, not valuesFiles

### DIFF
--- a/docs/docs/30-how-to-guides/10-configuration.mdx
+++ b/docs/docs/30-how-to-guides/10-configuration.mdx
@@ -145,7 +145,7 @@ branchConfigs:
         helm:
           releaseName: bar
           namespace: bar #optional
-          valuesFiles:
+          valueFiles:
           - env/test/bar/values.yaml
       outputPath: bar
 - name: env/stage
@@ -156,7 +156,7 @@ branchConfigs:
         helm:
           releaseName: foo
           namespace: foo #optional
-          valuesFiles:
+          valueFiles:
           - env/stage/foo/values.yaml
       outputPath: foo
     bar:
@@ -165,7 +165,7 @@ branchConfigs:
         helm:
           releaseName: bar
           namespace: bar #optional
-          valuesFiles:
+          valueFiles:
           - env/stage/bar/values.yaml
       outputPath: bar
 - name: env/prod
@@ -176,7 +176,7 @@ branchConfigs:
         helm:
           releaseName: foo
           namespace: foo #optional
-          valuesFiles:
+          valueFiles:
           - env/prod/foo/values.yaml
       outputPath: foo
     bar:
@@ -185,7 +185,7 @@ branchConfigs:
         helm:
           releaseName: bar
           namespace: bar #optional
-          valuesFiles:
+          valueFiles:
           - env/prod/bar/values.yaml
       outputPath: bar
 ```
@@ -248,7 +248,7 @@ branchConfigs:
         helm:
           releaseName: foo
           namespace: foo #optional
-          valuesFiles:
+          valueFiles:
           - env/${1}/foo/values.yaml
       outputPath: foo
     bar:
@@ -257,7 +257,7 @@ branchConfigs:
         helm:
           releaseName: bar
           namespace: bar #optional
-          valuesFiles:
+          valueFiles:
           - env/${1}/bar/values.yaml
       outputPath: bar
 ```

--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -17,7 +17,7 @@ easiest option for experimenting locally with Kargo Render!
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.25 \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.34 \
   kargo-render render \
   --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \


### PR DESCRIPTION
This has tripped me up with Argo CD since 2019 :)

Also, updating `docker run` example to reference latest rc.34 (which has backwards breaking changes).