### PR TITLE
docs: GitHub Action is kargo-render-action, not akuity-kargo-render

### DIFF
--- a/docs/docs/30-how-to-guides/20-github-actions.md
+++ b/docs/docs/30-how-to-guides/20-github-actions.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Render manifests
-      uses: akuity/akuity-kargo-render@v0.1.0-rc.25
+      uses: akuity/kargo-render-action@v0.1.0-rc.34
       with:
         personalAccessToken: ${{ secrets.GITHUB_TOKEN }}
         targetBranch: env/test


### PR DESCRIPTION
I briefly got confused by the name of the GitHub Action referenced in the docs.  I've submitted a similar PR to update the README in the 'kargo-render-action' project too (https://github.com/akuity/kargo-render-action/pull/3).  Also, updated version to latest latest rc.34.