### PR TITLE
fix: do not pass relative path and empty repoRoot to repo server

### DIFF
--- a/internal/argocd/render.go
+++ b/internal/argocd/render.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -88,7 +89,8 @@ func (c ConfigManagementConfig) Expand(
 }
 
 func Render(
-	ctx context.Context, path string,
+	ctx context.Context,
+	repoRoot string,
 	cfg ConfigManagementConfig,
 ) ([]byte, error) {
 	src := argoappv1.ApplicationSource{
@@ -113,13 +115,9 @@ func Render(
 
 	res, err := repository.GenerateManifests(
 		ctx,
-		path,
-		// Seems ok for these next two arguments to be empty strings. If this is
-		// last mile rendering, we might be doing this in a directory outside of any
-		// repo. And event for regular rendering, we have already checked the
-		// revision we want.
-		"", // Repo root
-		"", // Revision
+		filepath.Join(repoRoot, cfg.Path),
+		repoRoot, // Repo root
+		"",       // Revision -- seems ok to be empty string
 		&apiclient.ManifestRequest{
 			// Both of these fields need to be non-nil
 			Repo:              &argoappv1.Repository{},

--- a/rendering.go
+++ b/rendering.go
@@ -24,7 +24,7 @@ resources:
 func (s *service) preRender(
 	ctx context.Context,
 	rc requestContext,
-	repoDir string,
+	repoRoot string,
 ) (map[string][]byte, error) {
 	logger := rc.logger
 	manifests := map[string][]byte{}
@@ -33,7 +33,7 @@ func (s *service) preRender(
 		appLogger := logger.WithField("app", appName)
 		manifests[appName], err = s.renderFn(
 			ctx,
-			filepath.Join(repoDir, appConfig.ConfigManagement.Path),
+			repoRoot,
 			appConfig.ConfigManagement,
 		)
 		if err != nil {

--- a/service.go
+++ b/service.go
@@ -30,7 +30,7 @@ type service struct {
 	logger   *log.Logger
 	renderFn func(
 		ctx context.Context,
-		path string,
+		repoRoot string,
 		cfg argocd.ConfigManagementConfig,
 	) ([]byte, error)
 }


### PR DESCRIPTION
When invoking the repo server, we've been passing (typically) a relative `path` (aka `appPath` in Argo CD code) and an empty `repoRoot`.

This has been adversely impacting our ability to resolve Helm values files under certain circumstances.

e.g.:

```
error pre-rendering manifests: error generating manifests using Argo CD repo server: error resolving helm value files: error resolving value file path: file 'env/dev/values.yaml' resolved to outside repository root
```

[This comment](https://github.com/argoproj/argo-cd/blob/master/util/io/path/resolved.go#L84-L111) from within Argo CD source code explains:

```golang
// ResolveValueFilePathOrUrl will inspect and resolve given file, and make sure that its final path is within the boundaries of
// the path specified in repoRoot.
//
// appPath is the path we're operating in, e.g. where a Helm chart was unpacked
// to. repoRoot is the path to the root of the repository.
//
// If either appPath or repoRoot is relative, it will be treated as relative
// to the current working directory.
```

Typically, when executing Kargo render from the command line as follows, the working directory is `/` and everything works because _all paths are within `/`_.

```shell
docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.34 kargo-render render --repo <repo> --target-branch <branch> --repo-username <username> --repo-password <PAT>
```

When the same container is used as part of the [Kargo Render GitHub Action](https://github.com/akuity/kargo-render-action/blob/main/action.yaml), GitHub sets the working directory to `/__w/<repo-name>/<repo-name>` -- and there is no getting around that, short of programmatically changing the working directory when the executable launches -- which seems heavy-handed. With the working directory set this way, and some relative paths evaluated relative to _this_, the resolved absolute paths of Helm value files appear to lie outside the repository, producing the error referenced at the top of the issue.

The changes in this PR fix the root problem (pun semi-intended), by always passing an absolute `repoRoot` and `appPath` to the repo server.

