### PR TITLE
docs: use common language to keep content accessible

### DIFF
--- a/docs/docs/30-how-to-guides/10-configuration.mdx
+++ b/docs/docs/30-how-to-guides/10-configuration.mdx
@@ -39,7 +39,7 @@ deploying multiple, distinct, monolithic applications that can be deployed
 independently of one another.
 
 With an _environment-centric_ perspective, a team treats their environments as
-"first class." _Applications_ are simply different denizens of an environment.
+"first class." _Applications_ are simply different pieces of an environment.
 This perspective might be adopted by a team that is employing a microsevice
 architecture wherein each "application" is a single component of a larger whole
 that should be deployed as an atomic unit.


### PR DESCRIPTION
I think it's fair to say that not everyone's first language is English, and when that's the case, coming across words like `denizens` makes it difficult to understand an already complex topic. Frankly, it's a word I didn't know but could understand with context and definition. However, I think it would make the docs more accessible to use a more familiar (simpler?) word to get the same point across.

I won't die on this hill, but I wanted to open up the conversation!

> Yeah, this whole PR is a nit, but I like semantics :smile: