### PR TITLE
feat: add options for where input comes from and where output goes to

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run unit tests
+      env:
+        TEST_GIT_CLIENT_WITH_AUTH: true
       run: make test-unit
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,5 @@
 run:
   go: "1.22"
-  build-tags:
-    - integration
   deadline: 10m
 
 linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,7 @@
 run:
   go: "1.22"
+  build-tags:
+    - integration
   deadline: 10m
 
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ ENV XDG_CONFIG_HOME=/tmp/.config
 ENV XDG_CACHE_HOME=/tmp/.cache
 ENV XDG_DATA_HOME=/tmp/.local/share
 
-CMD ["/usr/local/bin/kargo-render"]
+ENTRYPOINT ["/usr/local/bin/kargo-render"]

--- a/branches.go
+++ b/branches.go
@@ -84,10 +84,18 @@ func switchToTargetBranch(rc requestContext) error {
 
 	if targetBranchExists {
 		logger.Debug("target branch exists on remote")
+		if err = rc.repo.Fetch(); err != nil {
+			return fmt.Errorf("error fetching from remote: %w", err)
+		}
+		logger.Debug("fetched from remote")
 		if err = rc.repo.Checkout(rc.request.TargetBranch); err != nil {
 			return fmt.Errorf("error checking out target branch: %w", err)
 		}
 		logger.Debug("checked out target branch")
+		if err = rc.repo.Pull(rc.request.TargetBranch); err != nil {
+			return fmt.Errorf("error pulling from remote: %w", err)
+		}
+		logger.Debug("pulled from remote")
 		return nil
 	}
 

--- a/cmd/action_cmd.go
+++ b/cmd/action_cmd.go
@@ -87,8 +87,8 @@ func (o *actionOptions) run(_ context.Context, out io.Writer) error {
 	return nil
 }
 
-func request() (render.Request, error) {
-	req := render.Request{
+func request() (*render.Request, error) {
+	req := &render.Request{
 		RepoCreds: render.RepoCredentials{
 			Username: "git",
 		},
@@ -96,15 +96,15 @@ func request() (render.Request, error) {
 	}
 	repo, err := libOS.GetRequiredEnvVar("GITHUB_REPOSITORY")
 	if err != nil {
-		return req, err
+		return nil, err
 	}
 	req.RepoURL = fmt.Sprintf("https://github.com/%s", repo)
 	if req.RepoCreds.Password, err =
 		libOS.GetRequiredEnvVar("INPUT_PERSONALACCESSTOKEN"); err != nil {
-		return req, err
+		return nil, err
 	}
 	if req.Ref, err = libOS.GetRequiredEnvVar("GITHUB_SHA"); err != nil {
-		return req, err
+		return nil, err
 	}
 	req.TargetBranch, err = libOS.GetRequiredEnvVar("INPUT_TARGETBRANCH")
 	return req, err

--- a/cmd/action_cmd_test.go
+++ b/cmd/action_cmd_test.go
@@ -22,7 +22,7 @@ func TestRequest(t *testing.T) {
 		testImage1 = "krancour/foo:blue"
 		testImage2 = "krancour/foo:green"
 	)
-	testReq := render.Request{
+	testReq := &render.Request{
 		RepoURL: fmt.Sprintf("https://github.com/%s", testRepo),
 		RepoCreds: render.RepoCredentials{
 			Username: "git",
@@ -35,11 +35,11 @@ func TestRequest(t *testing.T) {
 	testCases := []struct {
 		name       string
 		setup      func()
-		assertions func(*testing.T, render.Request, error)
+		assertions func(*testing.T, *render.Request, error)
 	}{
 		{
 			name: "GITHUB_REPOSITORY not specified",
-			assertions: func(t *testing.T, _ render.Request, err error) {
+			assertions: func(t *testing.T, _ *render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "GITHUB_REPOSITORY")
@@ -50,7 +50,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("GITHUB_REPOSITORY", testRepo)
 			},
-			assertions: func(t *testing.T, _ render.Request, err error) {
+			assertions: func(t *testing.T, _ *render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "INPUT_PERSONALACCESSTOKEN")
@@ -61,7 +61,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("INPUT_PERSONALACCESSTOKEN", testReq.RepoCreds.Password)
 			},
-			assertions: func(t *testing.T, _ render.Request, err error) {
+			assertions: func(t *testing.T, _ *render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "GITHUB_SHA")
@@ -72,7 +72,7 @@ func TestRequest(t *testing.T) {
 			setup: func() {
 				t.Setenv("GITHUB_SHA", testReq.Ref)
 			},
-			assertions: func(t *testing.T, _ render.Request, err error) {
+			assertions: func(t *testing.T, _ *render.Request, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
 				require.Contains(t, err.Error(), "INPUT_TARGETBRANCH")
@@ -86,7 +86,7 @@ func TestRequest(t *testing.T) {
 					"INPUT_IMAGES",
 					fmt.Sprintf("%s,%s", testImage1, testImage2))
 			},
-			assertions: func(t *testing.T, req render.Request, err error) {
+			assertions: func(t *testing.T, req *render.Request, err error) {
 				require.NoError(t, err)
 				require.Equal(t, testReq, req)
 			},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -5,6 +5,8 @@ const (
 	flagCommitMessage = "commit-message"
 	flagDebug         = "debug"
 	flagImage         = "image"
+	flagLocalInPath   = "local-in-path"
+	flagLocalOutPath  = "local-out-path"
 	flagOutput        = "output"
 	flagOutputJSON    = "json"
 	flagOutputYAML    = "yaml"
@@ -12,5 +14,6 @@ const (
 	flagRepo          = "repo"
 	flagRepoPassword  = "repo-password"
 	flagRepoUsername  = "repo-username"
+	flagStdout        = "stdout"
 	flagTargetBranch  = "target-branch"
 )

--- a/context.go
+++ b/context.go
@@ -8,7 +8,7 @@ import (
 
 type requestContext struct {
 	logger       *log.Entry
-	request      Request
+	request      *Request
 	repo         git.Repo
 	source       sourceContext
 	intermediate intermediateContext

--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -17,8 +17,7 @@ easiest option for experimenting locally with Kargo Render!
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.34 \
-  kargo-render render \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.36 \
   --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \
   --repo-password <a GitHub personal access token> \

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require k8s.io/apiserver v0.24.17 // indirect
 require (
 	github.com/argoproj/argo-cd/v2 v2.9.9
 	github.com/google/go-github/v47 v47.1.0
+	github.com/sosedoff/gitkit v0.4.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 )
 
@@ -95,6 +96,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-redis/cache/v9 v9.0.0 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -621,6 +623,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/sosedoff/gitkit v0.4.0 h1:opyQJ/h9xMRLsz2ca/2CRXtstePcpldiZN8DpLLF8Os=
+github.com/sosedoff/gitkit v0.4.0/go.mod h1:V3EpGZ0nvCBhXerPsbDeqtyReNb48cwP9KtkUYTKT5I=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -749,6 +753,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,6 +13,8 @@ import (
 	libExec "github.com/akuity/kargo-render/internal/exec"
 )
 
+const RemoteOrigin = "origin"
+
 // RepoCredentials represents the credentials for connecting to a private git
 // repository.
 type RepoCredentials struct {
@@ -391,7 +393,7 @@ func (r *repo) CommitMessages(id1, id2 string) ([]string, error) {
 }
 
 func (r *repo) Fetch() error {
-	if _, err := libExec.Exec(r.buildCommand("fetch", "origin")); err != nil {
+	if _, err := libExec.Exec(r.buildCommand("fetch", RemoteOrigin)); err != nil {
 		return fmt.Errorf("error fetching from remote repo %q: %w", r.url, err)
 	}
 	return nil
@@ -399,7 +401,7 @@ func (r *repo) Fetch() error {
 
 func (r *repo) Pull(branch string) error {
 	if _, err :=
-		libExec.Exec(r.buildCommand("pull", "origin", branch)); err != nil {
+		libExec.Exec(r.buildCommand("pull", RemoteOrigin, branch)); err != nil {
 		return fmt.Errorf(
 			"error pulling branch %q from remote repo %q: %w",
 			branch,
@@ -412,7 +414,7 @@ func (r *repo) Pull(branch string) error {
 
 func (r *repo) Push() error {
 	if _, err :=
-		libExec.Exec(r.buildCommand("push", "origin", r.currentBranch)); err != nil {
+		libExec.Exec(r.buildCommand("push", RemoteOrigin, r.currentBranch)); err != nil {
 		return fmt.Errorf("error pushing branch %q: %w", r.currentBranch, err)
 	}
 	return nil
@@ -423,7 +425,7 @@ func (r *repo) RemoteBranchExists(branch string) (bool, error) {
 		"ls-remote",
 		"--heads",
 		"--exit-code", // Return 2 if not found
-		"origin",
+		RemoteOrigin,
 		branch,
 	)); err != nil {
 		if exitErr, ok := err.(*libExec.ExitError); ok && exitErr.ExitCode == 2 {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -316,7 +316,7 @@ func (r *repo) CreateOrphanedBranch(branch string) error {
 
 func (r *repo) HasDiffs() (bool, error) {
 	resBytes, err := libExec.Exec(r.buildCommand("status", "-s"))
-	if err == nil {
+	if err != nil {
 		return false,
 			fmt.Errorf("error checking status of branch %q: %w", r.currentBranch, err)
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,204 @@
+//go:build integration
+// +build integration
+
+package git
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// All test cases in this file are integration tests that rely on a remote git
+// repository. They're (for now) disabled by default.
+//
+// Run these against a repository you don't mind being messed with.
+//
+// To use your own repository and credentials, set env vars:
+// - TEST_REPO_URL
+// - TEST_REPO_USERNAME
+// - TEST_REPO_PASSWORD (personal access token)
+
+func TestRepo(t *testing.T) {
+	testRepoURL := os.Getenv("TEST_REPO_URL")
+
+	testRepoCreds := RepoCredentials{
+		Username: os.Getenv("TEST_REPO_USERNAME"),
+		Password: os.Getenv("TEST_REPO_PASSWORD"),
+	}
+
+	rep, err := Clone(testRepoURL, testRepoCreds)
+	require.NoError(t, err)
+	require.NotNil(t, rep)
+	r, ok := rep.(*repo)
+	require.True(t, ok)
+
+	t.Run("can clone", func(t *testing.T) {
+		require.Equal(t, testRepoURL, r.url)
+		require.NotEmpty(t, r.homeDir)
+		var fi os.FileInfo
+		fi, err = os.Stat(r.homeDir)
+		require.NoError(t, err)
+		require.True(t, fi.IsDir())
+		require.NotEmpty(t, r.dir)
+		fi, err = os.Stat(r.dir)
+		require.NoError(t, err)
+		require.True(t, fi.IsDir())
+		require.Equal(t, "HEAD", r.currentBranch)
+	})
+
+	t.Run("can get the repo url", func(t *testing.T) {
+		require.Equal(t, r.url, r.URL())
+	})
+
+	t.Run("can get the home dir", func(t *testing.T) {
+		require.Equal(t, r.homeDir, r.HomeDir())
+	})
+
+	t.Run("can get the working dir", func(t *testing.T) {
+		require.Equal(t, r.dir, r.WorkingDir())
+	})
+
+	t.Run("can list remotes", func(t *testing.T) {
+		var remotes []string
+		remotes, err = r.Remotes()
+		require.NoError(t, err)
+		require.Len(t, remotes, 1)
+		require.Equal(t, "origin", remotes[0])
+	})
+
+	t.Run("can get url of a remote", func(t *testing.T) {
+		var url string
+		url, err = r.RemoteURL("origin")
+		require.NoError(t, err)
+		require.Equal(t, r.url, url)
+	})
+
+	t.Run("can check if remote branch exists -- negative result", func(t *testing.T) {
+		testBranch := fmt.Sprintf("test-branch-%s", uuid.NewString())
+		var exists bool
+		exists, err = r.RemoteBranchExists(testBranch)
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("can check if remote branch exists -- positive result", func(t *testing.T) {
+		var exists bool
+		exists, err = r.RemoteBranchExists("main")
+		require.NoError(t, err)
+		require.True(t, exists)
+	})
+
+	t.Run("can fetch", func(t *testing.T) {
+		err = r.Fetch()
+		require.NoError(t, err)
+	})
+
+	t.Run("can pull", func(t *testing.T) {
+		err = r.Pull(r.currentBranch)
+		require.NoError(t, err)
+	})
+
+	t.Run("can create a child branch", func(t *testing.T) {
+		testBranch := fmt.Sprintf("test-branch-%s", uuid.NewString())
+		err = r.CreateChildBranch(testBranch)
+		require.NoError(t, err)
+	})
+
+	testBranch := fmt.Sprintf("test-branch-%s", uuid.NewString())
+	err = r.CreateOrphanedBranch(testBranch)
+
+	t.Run("can create an orphaned branch", func(t *testing.T) {
+		require.NoError(t, err)
+	})
+
+	t.Run("can check for diffs -- negative result", func(t *testing.T) {
+		var hasDiffs bool
+		hasDiffs, err = r.HasDiffs()
+		require.NoError(t, err)
+		require.False(t, hasDiffs)
+	})
+
+	err = os.WriteFile(fmt.Sprintf("%s/%s", r.WorkingDir(), "test.txt"), []byte("foo"), 0600)
+	require.NoError(t, err)
+
+	t.Run("can check for diffs -- positive result", func(t *testing.T) {
+		var hasDiffs bool
+		hasDiffs, err = r.HasDiffs()
+		require.NoError(t, err)
+		require.True(t, hasDiffs)
+	})
+
+	t.Run("can get diff paths", func(t *testing.T) {
+		var paths []string
+		paths, err = r.GetDiffPaths()
+		require.NoError(t, err)
+		require.Len(t, paths, 1)
+	})
+
+	testCommitMessage := fmt.Sprintf("test commit %s", uuid.NewString())
+	err = r.AddAllAndCommit(testCommitMessage)
+	require.NoError(t, err)
+
+	t.Run("can commit", func(t *testing.T) {
+		require.NoError(t, err)
+	})
+
+	lastCommitID, err := r.LastCommitID()
+	require.NoError(t, err)
+
+	t.Run("can get last commit id", func(t *testing.T) {
+		require.NoError(t, err)
+		require.NotEmpty(t, lastCommitID)
+	})
+
+	t.Run("can get commit message by id", func(t *testing.T) {
+		var msg string
+		msg, err = r.CommitMessage(lastCommitID)
+		require.NoError(t, err)
+		require.Equal(t, testCommitMessage, msg)
+	})
+
+	t.Run("can push", func(t *testing.T) {
+		err = r.Push()
+		require.NoError(t, err)
+	})
+
+	err = os.WriteFile(fmt.Sprintf("%s/%s", r.WorkingDir(), "test.txt"), []byte("bar"), 0600)
+	require.NoError(t, err)
+
+	t.Run("can hard reset", func(t *testing.T) {
+		err := r.ResetHard()
+		require.NoError(t, err)
+		hasDiffs, err := r.HasDiffs()
+		require.NoError(t, err)
+		require.False(t, hasDiffs)
+	})
+
+	t.Run("can copy an existing repo", func(t *testing.T) {
+		newRepo, err := CopyRepo(r.WorkingDir(), testRepoCreds)
+		require.NoError(t, err)
+		defer newRepo.Close()
+		require.NotNil(t, newRepo)
+		require.Equal(t, r.URL(), r.URL())
+		require.NotEqual(t, r.HomeDir(), newRepo.HomeDir())
+		fi, err := os.Stat(newRepo.HomeDir())
+		require.NoError(t, err)
+		require.True(t, fi.IsDir())
+		require.NotEqual(t, r.WorkingDir(), newRepo.WorkingDir())
+		fi, err = os.Stat(newRepo.WorkingDir())
+		require.NoError(t, err)
+		require.True(t, fi.IsDir())
+	})
+
+	t.Run("can close repo", func(t *testing.T) {
+		require.NoError(t, r.Close())
+		_, err := os.Stat(r.HomeDir())
+		require.Error(t, err)
+		require.True(t, os.IsNotExist(err))
+	})
+
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -78,12 +78,12 @@ func TestRepo(t *testing.T) {
 		remotes, err = r.Remotes()
 		require.NoError(t, err)
 		require.Len(t, remotes, 1)
-		require.Equal(t, "origin", remotes[0])
+		require.Equal(t, RemoteOrigin, remotes[0])
 	})
 
 	t.Run("can get url of a remote", func(t *testing.T) {
 		var url string
-		url, err = r.RemoteURL("origin")
+		url, err = r.RemoteURL(RemoteOrigin)
 		require.NoError(t, err)
 		require.Equal(t, r.url, url)
 	})

--- a/service.go
+++ b/service.go
@@ -108,7 +108,7 @@ func (s *service) RenderManifests(
 		if remotes, err = rc.repo.Remotes(); err != nil {
 			return res, fmt.Errorf("error getting remotes: %w", err)
 		}
-		if len(remotes) != 1 || remotes[0] != "origin" {
+		if len(remotes) != 1 || remotes[0] != git.RemoteOrigin {
 			return res, errors.New(
 				"local repository must have exactly one remote, which must be " +
 					"named \"origin\"; refusing to proceed",

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +23,7 @@ type ServiceOptions struct {
 // Implementations of this interface are transport-agnostic.
 type Service interface {
 	// RenderManifests handles a rendering request.
-	RenderManifests(context.Context, Request) (Response, error)
+	RenderManifests(context.Context, *Request) (Response, error)
 }
 
 type service struct {
@@ -54,7 +55,7 @@ func NewService(opts *ServiceOptions) Service {
 // nolint: gocyclo
 func (s *service) RenderManifests(
 	ctx context.Context,
-	req Request,
+	req *Request,
 ) (Response, error) {
 	req.id = uuid.NewString()
 
@@ -69,7 +70,7 @@ func (s *service) RenderManifests(
 	res := Response{}
 
 	var err error
-	if req, err = validateAndCanonicalizeRequest(req); err != nil {
+	if err = req.canonicalizeAndValidate(); err != nil {
 		return res, err
 	}
 	startEndLogger.Debug("validated rendering request")
@@ -79,20 +80,63 @@ func (s *service) RenderManifests(
 		request: req,
 	}
 
-	if rc.repo, err = git.Clone(
-		rc.request.RepoURL,
-		git.RepoCredentials{
-			SSHPrivateKey: rc.request.RepoCreds.SSHPrivateKey,
-			Username:      rc.request.RepoCreds.Username,
-			Password:      rc.request.RepoCreds.Password,
-		},
-	); err != nil {
-		return res, fmt.Errorf("error cloning remote repository: %w", err)
+	if rc.request.LocalInPath != "" {
+
+		// We'll be taking our input from a local directory which is presumably
+		// a git repository with the desired source commit already checked out.
+		//
+		// This is mainly useful when Kargo proper wishes to handle the reading and
+		// writing to/from remote repositories itself, leaving Kargo Render to
+		// handle rendering only.
+
+		if rc.repo, err = git.CopyRepo(
+			rc.request.LocalInPath,
+			git.RepoCredentials(rc.request.RepoCreds),
+		); err != nil {
+			return res, fmt.Errorf("error copying local repository: %w", err)
+		}
+		// Check if the working tree is dirty
+		var isDirty bool
+		if isDirty, err = rc.repo.HasDiffs(); err != nil {
+			return res, fmt.Errorf("error checking for diffs: %w", err)
+		}
+		if isDirty {
+			return res, errors.New("working tree is dirty; refusing to proceed")
+		}
+		// Check that there is exactly one remote and it's named "origin"
+		var remotes []string
+		if remotes, err = rc.repo.Remotes(); err != nil {
+			return res, fmt.Errorf("error getting remotes: %w", err)
+		}
+		if len(remotes) != 1 || remotes[0] != "origin" {
+			return res, errors.New(
+				"local repository must have exactly one remote, which must be " +
+					"named \"origin\"; refusing to proceed",
+			)
+		}
+
+	} else {
+
+		// Clone the remote repository ourselves
+
+		if rc.repo, err = git.Clone(
+			rc.request.RepoURL,
+			git.RepoCredentials{
+				SSHPrivateKey: rc.request.RepoCreds.SSHPrivateKey,
+				Username:      rc.request.RepoCreds.Username,
+				Password:      rc.request.RepoCreds.Password,
+			},
+		); err != nil {
+			return res, fmt.Errorf("error cloning remote repository: %w", err)
+		}
+
 	}
 	defer rc.repo.Close()
 
 	// TODO: Add some logging to this block
-	if rc.request.Ref == "" {
+	if rc.request.LocalInPath != "" || rc.request.Ref == "" {
+		// For either of these mutually exclusive cases, we don't know the source
+		// commit yet
 		if rc.source.commit, err = rc.repo.LastCommitID(); err != nil {
 			return res, fmt.Errorf("error getting last commit ID: %w", err)
 		}
@@ -192,21 +236,60 @@ func (s *service) RenderManifests(
 		return res, fmt.Errorf("error in last-mile manifest rendering: %w", err)
 	}
 
+	// If we're writing to stdout, we're done
+	if rc.request.Stdout {
+		res.ActionTaken = ActionTakenNone
+		res.Manifests = rc.target.renderedManifests
+		return res, nil
+	}
+
+	// Figure out where we're writing to
+	outputDir := rc.repo.WorkingDir()
+	if rc.request.LocalOutPath != "" {
+		outputDir = rc.request.LocalOutPath
+		// Create a directory for the output
+		if err = os.MkdirAll(outputDir, 0755); err != nil {
+			return res, fmt.Errorf(
+				"error creating local output directory %q: %w",
+				outputDir,
+				err,
+			)
+		}
+		defer func() {
+			if err != nil {
+				if rmErr := os.RemoveAll(outputDir); rmErr != nil {
+					logger.WithError(err).Error(
+						"error cleaning up local output directory",
+					)
+				}
+			}
+		}()
+	}
+
 	// Write branch metadata
 	if err = writeBranchMetadata(
 		rc.target.newBranchMetadata,
-		rc.repo.WorkingDir(),
+		outputDir,
 	); err != nil {
 		return res, fmt.Errorf("error writing branch metadata: %w", err)
 	}
 	logger.WithField("sourceCommit", rc.source.commit).
 		Debug("wrote branch metadata")
 
-	// Write the new fully-rendered manifests to the root of the repo
-	if err = writeAllManifests(rc); err != nil {
+	// Write the fully-rendered manifests to the root of the repo
+	if err = writeAllManifests(rc, outputDir); err != nil {
 		return res, err
 	}
 	logger.Debug("wrote all manifests")
+
+	// If we're writing to a local directory, we're done
+	if rc.request.LocalOutPath != "" {
+		res.ActionTaken = ActionTakenWroteToLocalPath
+		res.LocalPath = outputDir
+		return res, nil
+	}
+
+	// If we get to here, we're writing to the remote repository
 
 	// Before committing, check if we actually have any diffs from the head of
 	// this branch that are NOT just Kargo Render metadata. We'd have an error if
@@ -363,30 +446,30 @@ func buildCommitMessage(rc requestContext) (string, error) {
 	return formattedCommitMsg, nil
 }
 
-func writeAllManifests(rc requestContext) error {
+func writeAllManifests(rc requestContext, outputDir string) error {
 	for appName, appConfig := range rc.target.branchConfig.AppConfigs {
 		appLogger := rc.logger.WithField("app", appName)
-		var outputDir string
+		var appOutputDir string
 		if appConfig.OutputPath != "" {
-			outputDir = filepath.Join(rc.repo.WorkingDir(), appConfig.OutputPath)
+			appOutputDir = filepath.Join(outputDir, appConfig.OutputPath)
 		} else {
-			outputDir = filepath.Join(rc.repo.WorkingDir(), appName)
+			appOutputDir = filepath.Join(outputDir, appName)
 		}
 		var err error
 		if appConfig.CombineManifests {
 			appLogger.Debug("manifests will be combined into a single file")
 			err =
-				writeCombinedManifests(outputDir, rc.target.renderedManifests[appName])
+				writeCombinedManifests(appOutputDir, rc.target.renderedManifests[appName])
 		} else {
 			appLogger.Debug("manifests will NOT be combined into a single file")
-			err = writeManifests(outputDir, rc.target.renderedManifests[appName])
+			err = writeManifests(appOutputDir, rc.target.renderedManifests[appName])
 		}
 		appLogger.Debug("wrote manifests")
 		if err != nil {
 			return fmt.Errorf(
 				"error writing manifests for app %q to %q: %w",
 				appName,
-				outputDir,
+				appOutputDir,
 				err,
 			)
 		}


### PR DESCRIPTION
Fixes #229 and is a key enabler for https://github.com/akuity/kargo/issues/1330

Full context -- when I implement #1330, Kargo proper will begin treating Kargo Render more similarly to how it treats Kustomize and Helm. Kargo will coordinate clones, commits, PRs, etc. leaving _rendering only_ to Kargo Render.

New options:

* Kargo Render can be invoked with a path to an existing repo, which it will _copy_ to a temporary directory so that it can monkey around with it safely.

* Kargo Render can write output back to a remote repo (the default), a specified path (Kargo proper will use this option), or stdout (primarily for test/debugging purposes).

Kargo Render retains the ability to do its own clones, commits, etc., simply because the Kargo Render Action needs it.

Also, since I added some new, low-level git operations and we didn't have any test coverage on the existing operations, this PR also adds a suite of integration tests in that package. CI won't run them (for now), but they can be executed locally. Testing against the real git binary and a real repository was the most expedient option for the near-term.