### PR TITLE
docs: updating how-to-guide docs for docker instructions

### DIFF
--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -17,7 +17,9 @@ easiest option for experimenting locally with Kargo Render!
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.36 \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.35 \
+  kargo-render \
+  render \
   --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \
   --repo-password <a GitHub personal access token> \


### PR DESCRIPTION
correct docker image to one that exists, and added the required commands needed to run kargo-render

The image listed in the docs does not currently exist: 
```
docker pull  ghcr.io/akuity/kargo-render:v0.1.0-rc.36
Error response from daemon: manifest unknown
```

rc.35 matches the latest used by the github action: https://github.com/akuity/kargo-render-action/releases