### PR TITLE
improve how new branches are created

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"github.com/akuity/kargo-render/internal/file"
+	"github.com/akuity/kargo-render/pkg/git"
 )
 
 // branchMetadata encapsulates details about an environment-specific branch for
@@ -104,12 +105,12 @@ func switchToTargetBranch(rc requestContext) error {
 		return fmt.Errorf("error creating new target branch: %w", err)
 	}
 	logger.Debug("created target branch")
-	if err =
-		writeBranchMetadata(branchMetadata{}, rc.repo.WorkingDir()); err != nil {
-		return fmt.Errorf("error writing blank target branch metadata: %w", err)
-	}
-	logger.Debug("wrote blank target branch metadata")
-	if err = rc.repo.AddAllAndCommit("Initial commit"); err != nil {
+	if err = rc.repo.Commit(
+		"Initial commit",
+		&git.CommitOptions{
+			AllowEmpty: true,
+		},
+	); err != nil {
 		return fmt.Errorf("error making initial commit to new target branch: %w", err)
 	}
 	logger.Debug("made initial commit to new target branch")

--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -17,7 +17,7 @@ easiest option for experimenting locally with Kargo Render!
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.36 \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.37 \
   --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \
   --repo-password <a GitHub personal access token> \


### PR DESCRIPTION
As a safeguard, Kargo render has long refused to write rendered config to a branch that doesn't already appear to be managed via Kargo Render. The signal that a branch _is_ managed by Kargo Render has always been the existence of branch metadata in `.kargo-render/metadata.yaml`.

This means that when _creating_ new, orphaned, stage-specific branches, we have always written blank metadata to the new branch.

The trouble with this approach is that Kargo proper (rather than Kargo Render) will, at times, be responsible for creation of stage-specific branches -- and when doing so, it doesn't (and shouldn't) particularly care about writing Kargo Render metadata into that new branch.

This PR changes some internal Kargo Render logic so that if we check out an existing branch that doesn't already appear to be managed via Kargo Render, we won't refuse to write to it as long as it's 100% empty. The corollary to this is that when Kargo Render creates new branches, it no longer needs to write blank metadata to them.

So, overall, this is actually quite a simplification.