### PR TITLE
fix: preserve files correctly when rendering to a local directory

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -3,11 +3,13 @@ package render
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
 
+	libExec "github.com/akuity/kargo-render/internal/exec"
 	"github.com/akuity/kargo-render/internal/file"
 	"github.com/akuity/kargo-render/pkg/git"
 )
@@ -181,6 +183,18 @@ func cleanCommitBranch(dir string, preservedPaths []string) error {
 		),
 	)
 	return err
+}
+
+// copyBranchContents copies the entire contents of the source directory to the
+// destination directory, except for .git.
+func copyBranchContents(srcDir, dstDir string) error {
+	// nolint: gosec
+	if _, err := libExec.Exec(
+		exec.Command("cp", "-r", srcDir, dstDir),
+	); err != nil {
+		return err
+	}
+	return os.RemoveAll(filepath.Join(dstDir, ".git"))
 }
 
 // normalizePreservedPaths converts the relative paths in the preservedPaths

--- a/branches_test.go
+++ b/branches_test.go
@@ -20,9 +20,7 @@ func TestLoadBranchMetadata(t *testing.T) {
 		{
 			name: "metadata does not exist",
 			setup: func() string {
-				repoDir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				return repoDir
+				return t.TempDir()
 			},
 			assertions: func(t *testing.T, md *branchMetadata, err error) {
 				require.NoError(t, err)
@@ -32,10 +30,9 @@ func TestLoadBranchMetadata(t *testing.T) {
 		{
 			name: "invalid YAML",
 			setup: func() string {
-				repoDir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
+				repoDir := t.TempDir()
 				bkDir := filepath.Join(repoDir, ".kargo-render")
-				err = os.Mkdir(bkDir, 0755)
+				err := os.Mkdir(bkDir, 0755)
 				require.NoError(t, err)
 				err = os.WriteFile(
 					filepath.Join(bkDir, "metadata.yaml"),
@@ -53,10 +50,9 @@ func TestLoadBranchMetadata(t *testing.T) {
 		{
 			name: "valid YAML",
 			setup: func() string {
-				repoDir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
+				repoDir := t.TempDir()
 				bkDir := filepath.Join(repoDir, ".kargo-render")
-				err = os.Mkdir(bkDir, 0755)
+				err := os.Mkdir(bkDir, 0755)
 				require.NoError(t, err)
 				err = os.WriteFile(
 					filepath.Join(bkDir, "metadata.yaml"),
@@ -80,9 +76,8 @@ func TestLoadBranchMetadata(t *testing.T) {
 }
 
 func TestWriteBranchMetadata(t *testing.T) {
-	repoDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	err = writeBranchMetadata(
+	repoDir := t.TempDir()
+	err := writeBranchMetadata(
 		branchMetadata{
 			SourceCommit: "1234567",
 		},
@@ -162,9 +157,7 @@ func TestNormalizePreservedPaths(t *testing.T) {
 }
 
 func TestCleanDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	defer os.RemoveAll(dir)
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	// This is what the test directory structure will look like:
 	// .
@@ -178,7 +171,7 @@ func TestCleanDir(t *testing.T) {
 
 	// Create the test directory structure
 	fooDir := filepath.Join(dir, "foo")
-	err = os.Mkdir(fooDir, 0755)
+	err := os.Mkdir(fooDir, 0755)
 	require.NoError(t, err)
 	fooFile := filepath.Join(fooDir, "foo.txt")
 	err = os.WriteFile(fooFile, []byte("foo"), 0600)

--- a/config_test.go
+++ b/config_test.go
@@ -18,9 +18,8 @@ func TestLoadRepoConfig(t *testing.T) {
 		{
 			name: "invalid JSON",
 			setup: func() string {
-				dir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				err = os.WriteFile(
+				dir := t.TempDir()
+				err := os.WriteFile(
 					filepath.Join(dir, "kargo-render.json"),
 					[]byte("bogus"),
 					0600,
@@ -40,9 +39,8 @@ func TestLoadRepoConfig(t *testing.T) {
 		{
 			name: "invalid YAML",
 			setup: func() string {
-				dir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				err = os.WriteFile(
+				dir := t.TempDir()
+				err := os.WriteFile(
 					filepath.Join(dir, "kargo-render.yaml"),
 					[]byte("bogus"),
 					0600,
@@ -62,9 +60,8 @@ func TestLoadRepoConfig(t *testing.T) {
 		{
 			name: "valid JSON",
 			setup: func() string {
-				dir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				err = os.WriteFile(
+				dir := t.TempDir()
+				err := os.WriteFile(
 					filepath.Join(dir, "kargo-render.json"),
 					[]byte(`{"configVersion": "v1alpha1"}`),
 					0600,
@@ -79,9 +76,8 @@ func TestLoadRepoConfig(t *testing.T) {
 		{
 			name: "valid YAML",
 			setup: func() string {
-				dir, err := os.MkdirTemp("", "")
-				require.NoError(t, err)
-				err = os.WriteFile(
+				dir := t.TempDir()
+				err := os.WriteFile(
 					filepath.Join(dir, "kargo-render.yaml"),
 					[]byte("configVersion: v1alpha1"),
 					0600,

--- a/docs/docs/30-how-to-guides/30-docker-image.md
+++ b/docs/docs/30-how-to-guides/30-docker-image.md
@@ -17,7 +17,7 @@ easiest option for experimenting locally with Kargo Render!
 Example usage:
 
 ```shell
-docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.37 \
+docker run -it ghcr.io/akuity/kargo-render:v0.1.0-rc.38 \
   --repo https://github.com/<your GitHub handle>/kargo-render-demo-deploy \
   --repo-username <your GitHub handle> \
   --repo-password <a GitHub personal access token> \

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,7 +13,11 @@ import (
 	libExec "github.com/akuity/kargo-render/internal/exec"
 )
 
-const RemoteOrigin = "origin"
+const (
+	RemoteOrigin = "origin"
+
+	tmpPrefix = "repo-"
+)
 
 // RepoCredentials represents the credentials for connecting to a private git
 // repository.
@@ -113,7 +117,7 @@ func Clone(
 	cloneURL string,
 	repoCreds RepoCredentials,
 ) (Repo, error) {
-	homeDir, err := os.MkdirTemp("", "")
+	homeDir, err := os.MkdirTemp("", tmpPrefix)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error creating home directory for repo %q: %w",
@@ -155,7 +159,7 @@ func CopyRepo(path string, repoCreds RepoCredentials) (Repo, error) {
 		return nil, fmt.Errorf("path %s is not a git repository: %w", path, err)
 	}
 
-	homeDir, err := os.MkdirTemp("", "")
+	homeDir, err := os.MkdirTemp("", tmpPrefix)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error creating directory for copy of repo at %s: %w",

--- a/rendering.go
+++ b/rendering.go
@@ -61,7 +61,7 @@ func renderLastMile(
 ) ([]string, map[string][]byte, error) {
 	logger := rc.logger
 
-	tempDir, err := os.MkdirTemp("", "")
+	tempDir, err := os.MkdirTemp("", "repo-scrap-")
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"error creating temporary directory %q for last mile rendering: %w",

--- a/service.go
+++ b/service.go
@@ -258,10 +258,9 @@ func (s *service) RenderManifests(
 	outputDir := rc.repo.WorkingDir()
 	if rc.request.LocalOutPath != "" {
 		outputDir = rc.request.LocalOutPath
-		// Create a directory for the output
-		if err = os.MkdirAll(outputDir, 0755); err != nil {
+		if err = copyBranchContents(rc.repo.WorkingDir(), outputDir); err != nil {
 			return res, fmt.Errorf(
-				"error creating local output directory %q: %w",
+				"error copying branch contents to local output directory %q: %w",
 				outputDir,
 				err,
 			)

--- a/service_test.go
+++ b/service_test.go
@@ -35,10 +35,8 @@ metadata:
 		},
 		[]byte("---\n"),
 	)
-	testDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
-	err = writeManifests(testDir, testYAMLBytes)
+	testDir := t.TempDir()
+	err := writeManifests(testDir, testYAMLBytes)
 	require.NoError(t, err)
 	filename := filepath.Join(testDir, "foobar-deployment.yaml")
 	exists, err := file.Exists(filename)


### PR DESCRIPTION
When we write to a stage-specific branch, we gut its existing contents entirely and render into the empty directory. The long-time exception to that has been that we do _not_ delete any files or directories explicitly named in the Kargo Render config as `preservedPaths`.

Only if writing to a local directory instead of a remote branch, all files that were meant to be preserved are going missing. The reason is that we have been rendering into a _brand new, empty directory_, when really, we should have been _copying_ whatever was to be preserved from the target branch.

Note that since I worked on a new test case that involved a temporary directory, I have also taken the liberty of fixing a few outstanding temp directory-related nits.