### PR TITLE
feat: add gpg and gpg-agent to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 FROM alpine:3.19.1 as final
 
 RUN apk update \
-    && apk add git openssh-client \
+    && apk add git gpg gpg-agent openssh-client \
     && addgroup -S -g 65532 nonroot \
     && adduser -S -D -H -u 65532 -g nonroot -G nonroot nonroot
 


### PR DESCRIPTION
Contributes to https://github.com/akuity/kargo/issues/1758

The `kargo-render` image is used as a base image for `kargo`[^1]. To allow Kargo to sign commits when using `git`, one of the necessary requirements is the GPG toolset. Alternative signing methods exist, but the recommended approach is GPG by default.

[^1]: https://github.com/akuity/kargo/blob/0c5b3b7c4562a2025ec0a0c3030ad5fbc46a0bfa/Dockerfile#L107