### PR TITLE
chore(deps): bump kustomize version on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -L -o /tmp/helm.tar.gz \
       https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
     && tar xvfz /tmp/helm.tar.gz -C /usr/local/bin --strip-components 1
 
-ARG KUSTOMIZE_VERSION=v5.1.1
+ARG KUSTOMIZE_VERSION=v5.4.1
 RUN curl -L -o /tmp/kustomize.tar.gz \
       https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz \
     && tar xvfz /tmp/kustomize.tar.gz -C /usr/local/bin
@@ -25,7 +25,7 @@ WORKDIR /kargo-render
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
-COPY . . 
+COPY . .
 
 ARG VERSION
 ARG GIT_COMMIT


### PR DESCRIPTION
fixes issues like #222 where kustomize is trying to use flag `--repo` on `helm pull` for oci:// repositories