### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,25 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    groups:
-      go-patch:
-        update-types:
-        - "patch"
-      go-minor:
-        update-types:
-        - "minor"
-      go-major:
-        update-types:
-        - "major"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: "chore(deps):"
+  groups:
+    go-patch:
+      update-types:
+      - "patch"
+    go-minor:
+      update-types:
+      - "minor"
+    go-major:
+      update-types:
+      - "major"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: "chore(deps):"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest
@@ -30,6 +33,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
+    permissions:
+      checks: write # Used to create checks (linting comments) on PRs
     runs-on: ubuntu-latest
     container:
       image: golang:1.22.5-bookworm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,15 +9,14 @@ on:
     - main
 
 jobs:
-
   test-unit:
     runs-on: ubuntu-latest
     container:
       image: golang:1.22.5-bookworm
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-    - uses: actions/cache@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: /go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -26,7 +25,7 @@ jobs:
     - name: Run unit tests
       run: make test-unit
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -36,15 +35,15 @@ jobs:
       image: golang:1.22.5-bookworm
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-    - uses: actions/cache@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: /go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
       env:
         GOFLAGS: -buildvcs=false
       with:
@@ -60,20 +59,20 @@ jobs:
         - 5000:5000
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       with:
         driver-opts: network=host
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Build base image
       run: |
         BASE_IMAGE=localhost:5000/kargo-render-base:latest make build-base-image
         docker push localhost:5000/kargo-render-base:latest-arm64
         docker push localhost:5000/kargo-render-base:latest-amd64
     - name: Build final image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
       with:
         build-args: |
           BASE_IMAGE=localhost:5000/kargo-render-base

--- a/.github/workflows/governance.yaml
+++ b/.github/workflows/governance.yaml
@@ -1,17 +1,23 @@
 # Documentation: https://github.com/BirthdayResearch/oss-governance-bot
+name: Governance
+
 on:
-    pull_request_target:
-      types: [ synchronize, opened, labeled, unlabeled ]
-    issues:
-      types: [ opened, labeled, unlabeled ]
-    issue_comment:
-      types: [ created ]
+  pull_request_target:
+    types: [ synchronize, opened, labeled, unlabeled ]
+  issues:
+    types: [ opened, labeled, unlabeled ]
+  issue_comment:
+    types: [ created ]
 
 jobs:
-    governance:
-        name: Governance
-        runs-on: ubuntu-latest
-        steps:
-          - uses: BirthdayResearch/oss-governance-bot@37c8583c6b8596d173b68ffaed543e2485f4f193 # v3.0.0
-            with:
-              config-path: .github/governance.yml
+  governance:
+    name: Governance
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: BirthdayResearch/oss-governance-bot@37c8583c6b8596d173b68ffaed543e2485f4f193 # v3.0.0
+      with:
+        config-path: .github/governance.yml

--- a/.github/workflows/governance.yaml
+++ b/.github/workflows/governance.yaml
@@ -12,7 +12,6 @@ jobs:
         name: Governance
         runs-on: ubuntu-latest
         steps:
-            - uses: BirthdayResearch/oss-governance-bot@v3
-              with:
-                config-path: .github/governance.yml
-    
+          - uses: BirthdayResearch/oss-governance-bot@37c8583c6b8596d173b68ffaed543e2485f4f193 # v3.0.0
+            with:
+              config-path: .github/governance.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,26 +19,26 @@ jobs:
         - 5000:5000
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       with:
         driver-opts: network=host
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.5.0
+      uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
       with:
         cosign-release: 'v2.2.1'
     - name: Login to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1      with:
       with:
         images: ghcr.io/akuity/kargo-render
         flavor: latest=false
@@ -49,7 +49,7 @@ jobs:
         docker push localhost:5000/kargo-render-base:latest-arm64
         docker push localhost:5000/kargo-render-base:latest-amd64
     - name: Build and push final image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
       with:
         platforms: linux/amd64,linux/arm64
         build-args: |
@@ -66,8 +66,9 @@ jobs:
         TAGS: ${{ steps.meta.outputs.tags }}
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-      run: cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+      run: |
+        cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
     - name: Publish SBOM
-      uses: anchore/sbom-action@v0
+      uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17.0
       with:
         image: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
     - created
 
 jobs:
-
   build-and-push-image:
     permissions:
       packages: write # Used to push images to ghcr.io


### PR DESCRIPTION
- Pin actions to SHAs.
- Set permissions on all workflows.
- Enable Dependabot for GitHub Actions.