### PR TITLE
update image signing process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,11 +6,15 @@ on:
     - created
 
 jobs:
-  build-and-push-image:
+
+  publish-image:
     permissions:
-      packages: write # Used to push images to ghcr.io
       contents: write # Used to upload assets
+      packages: write # Used to push images to `ghcr.io`
+      id-token: write # Needed to create an OIDC token for keyless signing
     runs-on: ubuntu-latest
+    outputs:
+      image-digest: ${{ steps.image.outputs.digest }}
     services:
       registry:
         image: registry:2
@@ -48,6 +52,7 @@ jobs:
         docker push localhost:5000/kargo-render-base:latest-arm64
         docker push localhost:5000/kargo-render-base:latest-amd64
     - name: Build and push final image
+      id: image
       uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
       with:
         platforms: linux/amd64,linux/arm64
@@ -60,14 +65,33 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        provenance: false
+        sbom: false
     - name: Sign image
-      env:
-        TAGS: ${{ steps.meta.outputs.tags }}
-        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
       run: |
-        cosign sign --key env://COSIGN_PRIVATE_KEY ${TAGS}
+        cosign sign \
+        -a "repo=${{ github.repository }}" \
+        -a "workflow=${{ github.workflow }}" \
+        -a "sha=${{ github.sha }}" \
+        --yes \
+        ghcr.io/akuity/kargo-render@${{ steps.image.outputs.digest}}
     - name: Publish SBOM
       uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5 # v0.17.0
       with:
         image: ${{ steps.meta.outputs.tags }}
+
+  image-provenance:
+    needs:
+    - publish-image
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations. (https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#known-issues)
+    # Must be referenced by a tag. https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/container/README.md#referencing-the-slsa-generator
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ghcr.io/akuity/kargo-render
+      digest: ${{ needs.publish-image.outputs.image-digest }}
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The [last attempted release](https://github.com/akuity/kargo-render/actions/runs/10271352103) of Kargo-Render failed, due it seems to the upgraded `cosign` binary that came in with #297.

This PR adjusts the image build and signing process to be more similar to that used by Kargo proper.

cc @34fathombelow 
