### PR TITLE
fix(manifests): split YAML using reader

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	libExec "github.com/akuity/kargo-render/internal/exec"
 	"github.com/akuity/kargo-render/internal/file"

--- a/cmd/kargo-render/output.go
+++ b/cmd/kargo-render/output.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func output(obj any, out io.Writer, format string) error {

--- a/config.go
+++ b/config.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/xeipuuv/gojsonschema"
+	"sigs.k8s.io/yaml"
 
 	"github.com/akuity/kargo-render/internal/argocd"
 	"github.com/akuity/kargo-render/internal/file"

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
@@ -158,7 +157,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
+	sigs.k8s.io/yaml v1.4.0
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -127,7 +127,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func JSONStringsToYAMLBytes(jsonManifests []string) ([][]byte, error) {
 	yamlManifests := make([][]byte, len(jsonManifests))
+
 	for i, jsonManifest := range jsonManifests {
 		var err error
 		if yamlManifests[i], err =

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -85,6 +85,44 @@ func TestSplitYAML(t *testing.T) {
 			},
 		},
 		{
+			name: "YAML containing separators within the spec",
+			manifests: []byte(`apiVersion: v1
+data:
+  mappings.yml: |-
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #   http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing,
+    # software distributed under the License is distributed on an
+    # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    # KIND, either express or implied.  See the License for the
+    # specific language governing permissions and limitations
+    # under the License.
+    ---
+    mappings:
+      some: mappings
+kind: ConfigMap
+metadata:
+  labels:
+    chart: airflow-1.11.0
+    component: config
+    heritage: Helm
+    release: airflow
+    tier: airflow
+  name: airflow-statsd`),
+			assertions: func(t *testing.T, manifests map[string][]byte, err error) {
+				require.NoError(t, err)
+				require.Len(t, manifests, 1)
+			},
+		},
+		{
 			name: "success",
 			manifests: []byte(`kind: foo
 metadata:


### PR DESCRIPTION
This is an alternative approach to #305, to solve the issues described in #278 and #294 using a YAML reader that properly understands YAML document separators.